### PR TITLE
feat(dec-001): C7 — kit install package + toreva CLI + examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,37 @@ Anyone - whether an SF-based AI researcher or a crypto-native builder - can brin
 [![Run on Repl.it](https://replit.com/badge/github/sendaifun/solana-agent-kit)](https://replit.com/@sendaifun/Solana-Agent-Kit)
 > Replit template created by [Arpit Singh](https://github.com/The-x-35)
 
+
+## Toreva CLI (DEC-001 C7 Kit Install)
+
+This repository now ships a standalone **`toreva`** installer CLI for MCP-aware clients.
+
+### Install
+
+```bash
+npx toreva init --client=claude-desktop
+```
+
+### First run
+
+```bash
+# 1) Install Toreva connector into your MCP-aware client config
+toreva init --client=claude-desktop
+
+# 2) Start token flow (gateway endpoint is currently stubbed)
+toreva login --gateway-url=https://gateway.stub.toreva.dev
+
+# 3) Verify install + token + first MCP call
+toreva doctor --client=claude-desktop
+```
+
+Supported clients:
+- `claude-desktop`
+- `openclaw`
+- `cursor`
+
+Client examples live under [`examples/toreva/`](examples/toreva).
+
 ## 🔧 Core Blockchain Features
 
 - **Token Operations**

--- a/bin/toreva
+++ b/bin/toreva
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import "../packages/toreva/bin/toreva.js";

--- a/examples/toreva/claude-desktop.json
+++ b/examples/toreva/claude-desktop.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "toreva": {
+      "command": "npx",
+      "args": ["-y", "@toreva/cdx-mcp"],
+      "env": {
+        "TOREVA_GATEWAY_URL": "https://gateway.stub.toreva.dev",
+        "TOREVA_TOKEN_FILE": "~/.config/toreva/credentials.json"
+      }
+    }
+  }
+}

--- a/examples/toreva/cursor.json
+++ b/examples/toreva/cursor.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "toreva": {
+      "command": "npx",
+      "args": ["-y", "@toreva/cdx-mcp"],
+      "env": {
+        "TOREVA_GATEWAY_URL": "https://gateway.stub.toreva.dev",
+        "TOREVA_TOKEN_FILE": "~/.config/toreva/credentials.json"
+      }
+    }
+  }
+}

--- a/examples/toreva/openclaw.json
+++ b/examples/toreva/openclaw.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "toreva": {
+      "command": "npx",
+      "args": ["-y", "@toreva/cdx-mcp"],
+      "env": {
+        "TOREVA_GATEWAY_URL": "https://gateway.stub.toreva.dev",
+        "TOREVA_TOKEN_FILE": "~/.config/toreva/credentials.json"
+      }
+    }
+  }
+}

--- a/packages/toreva/README.md
+++ b/packages/toreva/README.md
@@ -1,0 +1,3 @@
+# toreva
+
+CLI for Toreva MCP connector install/login/doctor workflows.

--- a/packages/toreva/bin/toreva.js
+++ b/packages/toreva/bin/toreva.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { runCli } from "../src/cli.js";
+
+runCli(process.argv.slice(2)).then((code) => {
+  process.exitCode = code;
+});

--- a/packages/toreva/package.json
+++ b/packages/toreva/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "toreva",
+  "version": "0.1.0",
+  "description": "Toreva kit installer CLI",
+  "type": "module",
+  "bin": {
+    "toreva": "bin/toreva.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  },
+  "license": "Apache-2.0"
+}

--- a/packages/toreva/src/cli.js
+++ b/packages/toreva/src/cli.js
@@ -1,0 +1,205 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_GATEWAY_URL = "https://gateway.stub.toreva.dev";
+const DEFAULT_MCP_HEALTH_PATH = "/mcp/health";
+
+const CLIENT_CONFIG_PATHS = {
+  "claude-desktop": path.join(
+    os.homedir(),
+    ".config",
+    "Claude",
+    "claude_desktop_config.json",
+  ),
+  openclaw: path.join(os.homedir(), ".config", "openclaw", "mcp.json"),
+  cursor: path.join(os.homedir(), ".cursor", "mcp.json"),
+};
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const flags = {};
+
+  for (const item of rest) {
+    if (!item.startsWith("--")) continue;
+    const [key, ...tail] = item.slice(2).split("=");
+    flags[key] = tail.length ? tail.join("=") : "true";
+  }
+
+  return { command, flags };
+}
+
+function getTokenFile(flags) {
+  return flags["token-file"]
+    ? path.resolve(flags["token-file"])
+    : path.join(os.homedir(), ".config", "toreva", "credentials.json");
+}
+
+async function readJson(filePath, fallback = {}) {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+async function writeJson(filePath, data) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+export async function initCommand(flags) {
+  const client = flags.client;
+  if (!client || !CLIENT_CONFIG_PATHS[client]) {
+    throw new Error(
+      "Invalid --client. Use claude-desktop, openclaw, or cursor.",
+    );
+  }
+
+  const configPath = flags.config
+    ? path.resolve(flags.config)
+    : CLIENT_CONFIG_PATHS[client];
+  const gatewayUrl = flags["gateway-url"] ?? DEFAULT_GATEWAY_URL;
+  const tokenFile = getTokenFile(flags);
+
+  const current = await readJson(configPath, {});
+  current.mcpServers = current.mcpServers ?? {};
+  current.mcpServers.toreva = {
+    command: flags["server-command"] ?? "npx",
+    args: flags["server-args"]
+      ? flags["server-args"].split(",")
+      : ["-y", "@toreva/cdx-mcp"],
+    env: {
+      TOREVA_GATEWAY_URL: gatewayUrl,
+      TOREVA_TOKEN_FILE: tokenFile,
+    },
+  };
+
+  await writeJson(configPath, current);
+
+  return { ok: true, client, configPath };
+}
+
+export async function loginCommand(flags, deps = { fetch: globalThis.fetch }) {
+  if (!deps.fetch) {
+    throw new Error("Fetch API is not available in this runtime.");
+  }
+
+  const gatewayUrl = flags["gateway-url"] ?? DEFAULT_GATEWAY_URL;
+  const tokenEndpoint = flags["token-endpoint"] ?? "/auth/token";
+  const tokenFile = getTokenFile(flags);
+
+  const response = await deps.fetch(`${gatewayUrl}${tokenEndpoint}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ client: "toreva-cli", stub: true }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Token flow failed with HTTP ${response.status}`);
+  }
+
+  const payload = await response.json();
+  if (!payload.accessToken) {
+    throw new Error("Token flow response missing accessToken");
+  }
+
+  await writeJson(tokenFile, {
+    accessToken: payload.accessToken,
+    tokenType: payload.tokenType ?? "Bearer",
+    issuedAt: new Date().toISOString(),
+    gatewayUrl,
+  });
+
+  return { ok: true, tokenFile };
+}
+
+export async function doctorCommand(flags, deps = { fetch: globalThis.fetch }) {
+  const client = flags.client;
+  if (!client || !CLIENT_CONFIG_PATHS[client]) {
+    throw new Error(
+      "Invalid --client. Use claude-desktop, openclaw, or cursor.",
+    );
+  }
+
+  const configPath = flags.config
+    ? path.resolve(flags.config)
+    : CLIENT_CONFIG_PATHS[client];
+  const tokenFile = getTokenFile(flags);
+  const mcpPath = flags["mcp-health-path"] ?? DEFAULT_MCP_HEALTH_PATH;
+
+  const config = await readJson(configPath, null);
+  if (!config?.mcpServers?.toreva) {
+    return { ok: false, checks: ["install:missing", "token:unknown", "mcp:skip"] };
+  }
+
+  const tokenData = await readJson(tokenFile, null);
+  if (!tokenData?.accessToken) {
+    return { ok: false, checks: ["install:ok", "token:missing", "mcp:skip"] };
+  }
+
+  if (!deps.fetch) {
+    return { ok: false, checks: ["install:ok", "token:ok", "mcp:fetch-unavailable"] };
+  }
+
+  const gatewayUrl =
+    flags["gateway-url"] ??
+    config.mcpServers.toreva.env?.TOREVA_GATEWAY_URL ??
+    DEFAULT_GATEWAY_URL;
+
+  const ping = await deps.fetch(`${gatewayUrl}${mcpPath}`, {
+    headers: {
+      authorization: `Bearer ${tokenData.accessToken}`,
+    },
+  });
+
+  if (!ping.ok) {
+    return { ok: false, checks: ["install:ok", "token:ok", `mcp:error:${ping.status}`] };
+  }
+
+  return { ok: true, checks: ["install:ok", "token:ok", "mcp:ok"] };
+}
+
+function printHelp() {
+  console.log(`toreva commands:
+  toreva init --client=claude-desktop|openclaw|cursor [--config=...] [--gateway-url=...]
+  toreva login [--gateway-url=...] [--token-endpoint=/auth/token] [--token-file=...]
+  toreva doctor --client=claude-desktop|openclaw|cursor [--config=...] [--token-file=...]
+`);
+}
+
+export async function runCli(argv, deps) {
+  const { command, flags } = parseArgs(argv);
+
+  try {
+    if (!command || command === "--help" || command === "help" || flags.help === "true") {
+      printHelp();
+      return 0;
+    }
+
+    if (command === "init") {
+      const result = await initCommand(flags);
+      console.log(`Installed Toreva MCP connector for ${result.client} at ${result.configPath}`);
+      return 0;
+    }
+
+    if (command === "login") {
+      const result = await loginCommand(flags, deps);
+      console.log(`Stored Toreva token in ${result.tokenFile}`);
+      return 0;
+    }
+
+    if (command === "doctor") {
+      const result = await doctorCommand(flags, deps);
+      console.log(`Doctor checks: ${result.checks.join(", ")}`);
+      return result.ok ? 0 : 1;
+    }
+
+    printHelp();
+    return 1;
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    return 1;
+  }
+}

--- a/packages/toreva/test/cli.test.mjs
+++ b/packages/toreva/test/cli.test.mjs
@@ -1,0 +1,98 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { doctorCommand, initCommand, loginCommand } from "../src/cli.js";
+
+async function mkTmpDir() {
+  return fs.mkdtemp(path.join(os.tmpdir(), "toreva-cli-"));
+}
+
+test("init writes Toreva MCP config for requested client", async () => {
+  const dir = await mkTmpDir();
+  const configPath = path.join(dir, "claude.json");
+
+  const result = await initCommand({
+    client: "claude-desktop",
+    config: configPath,
+    "token-file": path.join(dir, "token.json"),
+    "gateway-url": "https://gateway.example",
+  });
+
+  assert.equal(result.ok, true);
+  const json = JSON.parse(await fs.readFile(configPath, "utf8"));
+  assert.equal(json.mcpServers.toreva.command, "npx");
+  assert.deepEqual(json.mcpServers.toreva.args, ["-y", "@toreva/cdx-mcp"]);
+  assert.equal(
+    json.mcpServers.toreva.env.TOREVA_GATEWAY_URL,
+    "https://gateway.example",
+  );
+});
+
+test("login persists access token from mocked gateway flow", async () => {
+  const dir = await mkTmpDir();
+  const tokenFile = path.join(dir, "credentials.json");
+
+  const result = await loginCommand(
+    {
+      "gateway-url": "https://gateway.example",
+      "token-endpoint": "/auth/token",
+      "token-file": tokenFile,
+    },
+    {
+      fetch: async (url) => {
+        assert.equal(url, "https://gateway.example/auth/token");
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ accessToken: "tok_test_123", tokenType: "Bearer" }),
+        };
+      },
+    },
+  );
+
+  assert.equal(result.ok, true);
+  const stored = JSON.parse(await fs.readFile(tokenFile, "utf8"));
+  assert.equal(stored.accessToken, "tok_test_123");
+});
+
+test("doctor reports OK and error states", async () => {
+  const dir = await mkTmpDir();
+  const configPath = path.join(dir, "cursor.json");
+  const tokenFile = path.join(dir, "token.json");
+
+  await initCommand({ client: "cursor", config: configPath, "token-file": tokenFile });
+  await fs.writeFile(tokenFile, JSON.stringify({ accessToken: "tok_good" }));
+
+  const okResult = await doctorCommand(
+    {
+      client: "cursor",
+      config: configPath,
+      "token-file": tokenFile,
+      "gateway-url": "https://gateway.example",
+    },
+    {
+      fetch: async () => ({ ok: true, status: 200 }),
+    },
+  );
+
+  assert.equal(okResult.ok, true);
+  assert.deepEqual(okResult.checks, ["install:ok", "token:ok", "mcp:ok"]);
+
+  const errResult = await doctorCommand(
+    {
+      client: "cursor",
+      config: configPath,
+      "token-file": tokenFile,
+      "gateway-url": "https://gateway.example",
+    },
+    {
+      fetch: async () => ({ ok: false, status: 401 }),
+    },
+  );
+
+  assert.equal(errResult.ok, false);
+  assert.deepEqual(errResult.checks, ["install:ok", "token:ok", "mcp:error:401"]);
+});


### PR DESCRIPTION
### Motivation
- Ship the kit-side portion of DEC-001 C7 so MCP-capable clients can install and use the Toreva MCP connector. 
- Provide a lightweight, npx-installable installer CLI to bootstrap client configs, obtain gateway tokens, and validate the first MCP call.
- Surface a deterministic, stubbed token/gateway flow until the gateway MCP server is available. 
- Include examples and docs so downstream clients can adopt the connector with minimal friction.

### Description
- Add a new package `packages/toreva` containing an npx-installable CLI with a `bin` entry and a root shim at `bin/toreva` to run the command from the repo. 
- Implement `toreva init`, `toreva login`, and `toreva doctor` in `packages/toreva/src/cli.js`, including client config installation for `claude-desktop`, `openclaw`, and `cursor`, token persistence, and an MCP health check. 
- Add per-client example configs under `examples/toreva/` showing the `toreva` MCP server entry. 
- Update the root `README.md` with install and first-run UX for the `toreva` CLI and add unit tests in `packages/toreva/test/cli.test.mjs` covering `init`, mocked `login`, and `doctor` behaviors.

### Testing
- Ran unit tests with `node --test packages/toreva/test/*.test.mjs`, which passed all cases. 
- Executed the CLI help via `node packages/toreva/bin/toreva.js --help` to verify the top-level command and usage output, which returned successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed98e4dfa88322ab9c0dbaf4fbc064)